### PR TITLE
develop(common-form): 서비스 로직 개발 및 엔티티에 유틸리티 메소드 추가, 테스트 리팩토링

### DIFF
--- a/src/common-form/common-form.controller.ts
+++ b/src/common-form/common-form.controller.ts
@@ -16,33 +16,34 @@ export class CommonFormController {
   constructor(private readonly commonFormService: CommonFormService) {}
 
   @Post(':id')
-  create(
+  async create(
     @Param('id') id: string,
     @Body() createCommonFormDto: CreateCommonFormDto,
   ) {
-    return this.commonFormService.create(BigInt(+id), createCommonFormDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.commonFormService.findAll();
+    return await this.commonFormService.create(
+      BigInt(+id),
+      createCommonFormDto,
+    );
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.commonFormService.findOne(BigInt(+id));
+  async findOne(@Param('id') id: string) {
+    return await this.commonFormService.findOne(BigInt(+id));
   }
 
   @Patch(':id')
-  update(
+  async update(
     @Param('id') id: string,
     @Body() updateCommonFormDto: UpdateCommonFormDto,
   ) {
-    return this.commonFormService.update(BigInt(+id), updateCommonFormDto);
+    return await this.commonFormService.update(
+      BigInt(+id),
+      updateCommonFormDto,
+    );
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.commonFormService.remove(BigInt(+id));
+  async remove(@Param('id') id: string) {
+    return await this.commonFormService.remove(BigInt(+id));
   }
 }

--- a/src/common-form/common-form.service.spec.ts
+++ b/src/common-form/common-form.service.spec.ts
@@ -3,8 +3,9 @@ import { CommonFormService } from './common-form.service';
 import { CommonForm } from '../entities/common-form.entity';
 import { getRepositoryToken } from '@mikro-orm/nestjs';
 import { EntityManager, EntityRepository } from '@mikro-orm/core';
-import { UpdateCommonFormDto } from './dto/update-common-form.dto';
-import { plainToClass } from 'class-transformer';
+import { User } from '../entities/user.entity';
+import { NotFoundException } from '@nestjs/common';
+import { MikroORM } from '@mikro-orm/postgresql';
 
 function getCommonFormDto() {
   return {
@@ -27,14 +28,16 @@ function getCommonFormDto() {
 }
 
 function getCommonForm(): CommonForm {
-  const commonForm = plainToClass(CommonForm, getCommonFormDto());
+  const commonForm = new CommonForm();
+  Object.assign(commonForm, getCommonFormDto());
   commonForm.id = 1n;
   return commonForm;
 }
 
 describe('CommonFormService', () => {
   let service: CommonFormService;
-  let repository: EntityRepository<CommonForm>;
+  let userRepository: EntityRepository<User>;
+  let commonFormRepository: EntityRepository<CommonForm>;
   let entityManager: EntityManager;
 
   beforeEach(async () => {
@@ -44,149 +47,157 @@ describe('CommonFormService', () => {
         {
           provide: getRepositoryToken(CommonForm),
           useValue: {
-            findAll: jest.fn().mockResolvedValue([getCommonForm()]),
-            findOne: jest.fn().mockResolvedValue(getCommonForm()),
+            findOne: jest.fn(),
+            findOneOrFail: jest.fn(),
           },
         },
         {
-          provide: EntityManager, // EntityManager 모킹
+          provide: getRepositoryToken(User),
           useValue: {
-            persistAndFlush: jest.fn().mockResolvedValue(undefined),
-            removeAndFlush: jest.fn().mockResolvedValue(undefined),
-            findOne: jest.fn().mockResolvedValue(undefined),
+            findOne: jest.fn(),
+          },
+        },
+        {
+          provide: MikroORM,
+          useValue: {
+            em: {
+              persistAndFlush: jest.fn(),
+              removeAndFlush: jest.fn(),
+              nativeDelete: jest.fn(),
+            },
           },
         },
       ],
     }).compile();
 
     service = module.get<CommonFormService>(CommonFormService);
-    repository = module.get<EntityRepository<CommonForm>>(
+    userRepository = module.get<EntityRepository<User>>(
+      getRepositoryToken(User),
+    );
+    commonFormRepository = module.get<EntityRepository<CommonForm>>(
       getRepositoryToken(CommonForm),
     );
-    entityManager = module.get<EntityManager>(EntityManager);
+    entityManager = module.get<MikroORM>(MikroORM).em;
   });
 
   it('서비스가 정의되어 있어야 한다', () => {
-    // 'should be defined'
     expect(service).toBeDefined();
   });
 
-  describe('create', () => {
-    it('새로운 공통 양식을 생성해야 한다', async () => {
-      // 'should create a new common form'
+  describe('create 메서드', () => {
+    it('사용자를 기반으로 새로운 공통 양식을 생성해야 한다', async () => {
       const userId = 1n;
       const commonFormDto = getCommonFormDto();
-      await service.create(userId, commonFormDto);
-      expect(entityManager.persistAndFlush).toHaveBeenCalledWith(commonFormDto);
-    });
-  });
+      const user = new User();
+      user.id = userId;
 
-  describe('read', () => {
-    it('공통 양식 배열을 반환해야 한다', async () => {
-      // 'should return an array of common forms'
-      const commonForm1 = getCommonForm();
-      const commonForm2 = getCommonForm();
-      commonForm2.id = 2n;
-      jest
-        .spyOn(repository, 'findAll')
-        .mockResolvedValueOnce([commonForm1, commonForm2]);
-
-      const result = await service.findAll();
-      expect(entityManager.findAll).toHaveBeenCalled();
-      expect(result).toEqual([commonForm1, commonForm2]);
-    });
-
-    it('ID로 공통 양식을 반환해야 한다', async () => {
-      // 'should return a common form by id'
-      const commonForm = getCommonForm();
-      jest.spyOn(entityManager, 'findOne').mockResolvedValueOnce(commonForm);
-
-      const result = await service.findOne(1n);
-      expect(entityManager.findOne).toHaveBeenCalledWith(CommonForm, {
-        id: 1n,
-      });
-      expect(result).toBe(commonForm);
-    });
-  });
-
-  // UPDATE
-  describe('update', () => {
-    it('특정 ID에 해당하는 공통 양식을 업데이트해야 한다', async () => {
-      // 'should update a common form by id'
-      const updateFormDto: UpdateCommonFormDto = { careerMonths: 24 };
-      const commonForm = getCommonForm();
-      commonForm.careerMonths = 24;
-
-      jest.spyOn(entityManager, 'findOne').mockResolvedValueOnce(commonForm);
+      jest.spyOn(userRepository, 'findOne').mockResolvedValueOnce(user);
       jest
         .spyOn(entityManager, 'persistAndFlush')
         .mockResolvedValueOnce(undefined);
 
-      await service.update(1n, updateFormDto);
-      // ID로 엔티티가 조회되었는지 확인
-      expect(entityManager.findOne).toHaveBeenCalledWith(CommonForm, {
-        id: 1n,
-      });
+      await service.create(userId, commonFormDto);
+      expect(entityManager.persistAndFlush).toHaveBeenCalledWith(
+        expect.any(CommonForm),
+      );
+    });
 
-      // 엔티티가 업데이트된 후 저장되었는지 확인
+    it('존재하지 않는 사용자는 NotFoundException을 발생시켜야 한다', async () => {
+      const userId = 999n;
+      const commonFormDto = getCommonFormDto();
+
+      jest.spyOn(userRepository, 'findOne').mockResolvedValueOnce(null);
+
+      await expect(service.create(userId, commonFormDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('findOneByUser 메서드', () => {
+    it('사용자의 공통 양식을 반환해야 한다', async () => {
+      const userId = 1n;
+      const user = new User();
+      user.id = userId;
+      const commonForm = getCommonForm();
+
+      jest.spyOn(userRepository, 'findOne').mockResolvedValueOnce(user);
+      jest
+        .spyOn(commonFormRepository, 'findOneOrFail')
+        .mockResolvedValueOnce(commonForm);
+
+      const result = await service.findOneByUser(userId);
+      expect(result).toBe(commonForm);
+      expect(commonFormRepository.findOneOrFail).toHaveBeenCalledWith({ user });
+    });
+
+    it('존재하지 않는 사용자는 NotFoundException을 발생시켜야 한다', async () => {
+      const userId = 999n;
+
+      jest.spyOn(userRepository, 'findOne').mockResolvedValueOnce(null);
+
+      await expect(service.findOneByUser(userId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(commonFormRepository.findOneOrFail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('update 메서드', () => {
+    it('공통 양식을 업데이트해야 한다', async () => {
+      const id = 1n;
+      const updateFormDto = getCommonFormDto();
+      const commonForm = getCommonForm();
+
+      jest
+        .spyOn(commonFormRepository, 'findOneOrFail')
+        .mockResolvedValueOnce(commonForm);
+      jest
+        .spyOn(entityManager, 'persistAndFlush')
+        .mockResolvedValueOnce(undefined);
+
+      await service.update(id, updateFormDto);
       expect(entityManager.persistAndFlush).toHaveBeenCalledWith(commonForm);
     });
+
+    it('존재하지 않는 공통 양식은 NotFoundException을 발생시켜야 한다', async () => {
+      const id = 999n;
+      const updateFormDto = getCommonFormDto();
+
+      jest
+        .spyOn(commonFormRepository, 'findOneOrFail')
+        .mockRejectedValueOnce(new NotFoundException());
+
+      await expect(service.update(id, updateFormDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
   });
 
-  // DELETE - Idempotency
-  describe('delete', () => {
+  describe('remove 메서드', () => {
     it('공통 양식을 삭제해야 한다', async () => {
-      // 'should remove a common form'
-      jest.spyOn(entityManager, 'nativeDelete').mockResolvedValueOnce(1); // 삭제 성공 시
+      const id = 1n;
+      const commonForm = getCommonForm();
 
-      await service.remove(1n);
-      expect(entityManager.nativeDelete).toHaveBeenCalledWith(CommonForm, {
-        id: 1n,
-      });
+      jest
+        .spyOn(commonFormRepository, 'findOneOrFail')
+        .mockResolvedValueOnce(commonForm);
+      jest
+        .spyOn(entityManager, 'removeAndFlush')
+        .mockResolvedValueOnce(undefined);
+
+      await service.remove(id);
+      expect(entityManager.removeAndFlush).toHaveBeenCalledWith(commonForm);
     });
 
-    it('삭제할 공통 양식이 없어도 문제없이 작동해야 한다', async () => {
-      // 'should remove a common form'
-      jest.spyOn(entityManager, 'nativeDelete').mockResolvedValueOnce(0); // 삭제할 공통 양식이 없을 때
+    it('존재하지 않는 공통 양식 삭제 시 NotFoundException을 발생시켜야 한다', async () => {
+      const id = 999n;
 
-      await service.remove(10000n);
-      expect(entityManager.nativeDelete).toHaveBeenCalledWith(CommonForm, {
-        id: 10000n,
-      });
-    });
-  });
+      jest
+        .spyOn(commonFormRepository, 'findOneOrFail')
+        .mockRejectedValueOnce(new NotFoundException());
 
-  describe('create-exception', () => {
-    it('이미 공통 양식을 생성한 사용자가 다시 생성하려 하면 오류를 발생시켜야 한다', async () => {
-      // 'should throw an error if user has already created a common form'
-      const commonForm = new CommonForm();
-      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(commonForm);
-
-      await expect(service.create(1n, commonForm)).rejects.toThrow(
-        'User has already created a CommonForm',
-      );
-    });
-  });
-
-  describe('update-exception', () => {
-    it('공통 양식을 찾을 수 없으면 오류를 발생시켜야 한다', async () => {
-      // 'should throw an error if common form not found'
-      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(null);
-
-      await expect(service.findOne(999n)).rejects.toThrow(
-        'CommonForm not found',
-      );
-    });
-  });
-
-  describe('delete-exception', () => {
-    it('존재하지 않는 공통 양식을 삭제하려 하면 오류를 발생시켜야 한다', async () => {
-      // 'should throw an error if trying to remove a non-existent common form'
-      jest.spyOn(repository, 'findOne').mockResolvedValueOnce(null);
-
-      await expect(service.remove(999n)).rejects.toThrow(
-        'CommonForm not found',
-      );
+      await expect(service.remove(id)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/common-form/common-form.service.ts
+++ b/src/common-form/common-form.service.ts
@@ -1,36 +1,69 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateCommonFormDto } from './dto/create-common-form.dto';
 import { UpdateCommonFormDto } from './dto/update-common-form.dto';
 import { CommonForm } from '../entities/common-form.entity';
+import { EntityRepository, MikroORM } from '@mikro-orm/postgresql';
+import { InjectRepository } from '@mikro-orm/nestjs';
+import { User } from '../entities/user.entity';
+import { EntityManager } from '@mikro-orm/core';
 
 @Injectable()
 export class CommonFormService {
+  private readonly entityManager: EntityManager;
+
+  constructor(
+    @InjectRepository(CommonForm)
+    private readonly commonFormRepository: EntityRepository<CommonForm>,
+    @InjectRepository(User)
+    private readonly userRepository: EntityRepository<User>,
+    private readonly orm: MikroORM,
+  ) {
+    this.entityManager = this.orm.em;
+  }
+
   async create(
     id: bigint,
     createCommonFormDto: CreateCommonFormDto,
   ): Promise<bigint> {
-    return BigInt(id);
-    // return 'This action adds a new commonForm';
-  }
+    // Find user with id
+    const user = await this.findUser(id);
 
-  async findAll(): Promise<CommonForm[]> {
-    // return `This action returns all commonForm`;
-    return [];
+    // If exists, create commonForm with user and createCommonFormDto
+    const commonForm = new CommonForm(user, createCommonFormDto);
+
+    // save commonForm and return id
+    await this.entityManager.persistAndFlush(commonForm);
+    return commonForm.id;
   }
 
   async findOne(id: bigint): Promise<CommonForm> {
-    // return `This action returns a #${id} commonForm`;
-    return new CommonForm();
+    return await this.commonFormRepository.findOneOrFail({ id });
+  }
+
+  async findOneByUser(userId: bigint): Promise<CommonForm> {
+    const user = await this.findUser(userId);
+    return this.commonFormRepository.findOneOrFail({ user });
   }
 
   async update(
     id: bigint,
     updateCommonFormDto: UpdateCommonFormDto,
   ): Promise<void> {
-    // return `This action updates a #${id} commonForm`;
+    const commonForm = await this.commonFormRepository.findOneOrFail({ id });
+    commonForm.update(updateCommonFormDto);
+    await this.entityManager.persistAndFlush(commonForm);
   }
 
   async remove(id: bigint): Promise<void> {
-    // return `This action removes a #${id} commonForm`;
+    const commonForm = await this.commonFormRepository.findOneOrFail({ id });
+    await this.entityManager.removeAndFlush(commonForm);
+  }
+
+  private async findUser(id: bigint) {
+    const user = await this.userRepository.findOne({ id });
+    if (!user) {
+      throw new NotFoundException(`User with id ${id} not found`);
+    }
+    return user;
   }
 }

--- a/src/entities/common-form.entity.ts
+++ b/src/entities/common-form.entity.ts
@@ -6,9 +6,45 @@ import {
   Property,
 } from '@mikro-orm/core';
 import { User } from './user.entity';
+import { CreateCommonFormDto } from '../common-form/dto/create-common-form.dto';
+import { UpdateCommonFormDto } from '../common-form/dto/update-common-form.dto';
 
 @Entity()
 export class CommonForm {
+  constructor();
+  constructor(user: User, createCommonFormDto: CreateCommonFormDto);
+
+  constructor(user?: User, createCommonFormDto?: CreateCommonFormDto) {
+    if (!user || !createCommonFormDto) {
+      return;
+    }
+
+    this.user = user;
+    this.careerMonths = createCommonFormDto.careerMonths;
+    this.hsAbsenceDays = createCommonFormDto.hsAbsenceDays;
+    this.techCertificates = createCommonFormDto.techCertificates;
+    this.majorDepartment = createCommonFormDto.majorDepartment;
+    this.volunteerScore = createCommonFormDto.volunteerScore;
+    this.bloodDonation = createCommonFormDto.bloodDonation;
+    this.nationalMerit = createCommonFormDto.nationalMerit;
+    this.independenceMerit = createCommonFormDto.independenceMerit;
+    this.corpExpScore = createCommonFormDto.corpExpScore;
+    this.indivExpScore = createCommonFormDto.indivExpScore;
+    this.multiChildScore = createCommonFormDto.multiChildScore;
+    this.careerApply = createCommonFormDto.careerApply;
+    this.overseasApply = createCommonFormDto.overseasApply;
+    this.medicalApply = createCommonFormDto.medicalApply;
+    this.is_livelihood_recipient = createCommonFormDto.is_livelihood_recipient;
+  }
+
+  update(updateCommonFormDto: UpdateCommonFormDto) {
+    Object.entries(updateCommonFormDto).forEach(([key, value]) => {
+      if (value !== undefined) {
+        this[key] = value;
+      }
+    });
+  }
+
   @PrimaryKey({
     type: new BigIntType('bigint'),
     autoincrement: true,


### PR DESCRIPTION
- `CommonFormController`와 `CommonFormService`의 각 메소드에 `async-await` 처리
  - DB 접근 Task는 비동기 처리가 유리.
- `CommonFormService`에서 사용자 검증 및 `CommonForm` 생성 로직 개선:
  - `findUser` 메서드 추가로 사용자 존재 확인 및 예외 처리 추가
  - 생성자 및 업데이트 메서드에 `NotFoundException` 적용하여 비정상 요청 처리
- `CommonFormService`에 `findOneByUser` 메소드 추가:
  - 사용자 id로 해당 사용자의 공통 서식 쿼리 가능
- `CommonForm` 엔티티에 DTO 기반 생성자 및 업데이트 메서드 추가:
  - `CreateCommonFormDto`와 `UpdateCommonFormDto`를 통해 엔티티 필드를 초기화 및 업데이트 가능하도록 개선
- 테스트 코드 수정:
  - `userRepository` 및 `commonFormRepository`에 대한 Mock 설정 추가
  - 유효성 검사 및 예외 처리가 추가된 상황에 맞는 테스트 케이스 보강
  - `findAll`의 필요가 없다고 판단됨에 따라 테스트 삭제
    - 이에 따라 service, controller에서도 관련 더미 코드 삭제